### PR TITLE
Add DeepSeek authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ The Vertex AI API provides a [free tier](https://cloud.google.com/vertex-ai/gene
 
 3. (Optionally) Add a billing account on your project to get access to [higher usage limits](https://cloud.google.com/vertex-ai/generative-ai/docs/quotas)
 
+### Use a DeepSeek API key:
+
+1. Obtain an API key from DeepSeek.
+2. Set it as an environment variable in your terminal.
+
+   ```bash
+   export DEEPSEEK_API_KEY="YOUR_API_KEY"
+   ```
+
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 
 ## Examples

--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -39,7 +39,15 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
         source ~/.bashrc
         ```
 
-3.  **Vertex AI:**
+3.  **DeepSeek API Key:**
+
+- Obtain your API key from DeepSeek.
+- Set the `DEEPSEEK_API_KEY` environment variable. Optionally set `DEEPSEEK_BASE_URL` (defaults to `https://api.deepseek.com/v1`).
+  ```bash
+  export DEEPSEEK_API_KEY="YOUR_DEEPSEEK_API_KEY"
+  ```
+
+4.  **Vertex AI:**
     - Obtain your Google Cloud API key: [Get an API Key](https://cloud.google.com/vertex-ai/generative-ai/docs/start/api-keys?usertype=newuser)
       - Set the `GOOGLE_API_KEY` environment variable. In the following methods, replace `YOUR_GOOGLE_API_KEY` with your Vertex AI API key:
         - You can temporarily set these environment variables in your current shell session using the following commands:
@@ -69,7 +77,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
           echo 'export GOOGLE_CLOUD_LOCATION="YOUR_PROJECT_LOCATION"' >> ~/.bashrc
           source ~/.bashrc
           ```
-4.  **Cloud Shell:**
+5.  **Cloud Shell:**
     - This option is only available when running in a Google Cloud Shell environment.
     - It automatically uses the credentials of the logged-in user in the Cloud Shell environment.
     - This is the default authentication method when running in Cloud Shell and no other method is configured.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -288,6 +288,11 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Your API key for the Gemini API.
   - **Crucial for operation.** The CLI will not function without it.
   - Set this in your shell profile (e.g., `~/.bashrc`, `~/.zshrc`) or an `.env` file.
+- **`DEEPSEEK_API_KEY`**:
+  - Your DeepSeek API key.
+  - Example: `export DEEPSEEK_API_KEY="YOUR_DEEPSEEK_API_KEY"`.
+- **`DEEPSEEK_BASE_URL`**:
+  - Base URL for the DeepSeek API. Defaults to `https://api.deepseek.com/v1`.
 - **`GEMINI_MODEL`**:
   - Specifies the default Gemini model to use.
   - Overrides the hardcoded default

--- a/package-lock.json
+++ b/package-lock.json
@@ -8288,6 +8288,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.10.1.tgz",
+      "integrity": "sha512-fq6xVfv1/gpLbsj8fArEt3b6B9jBxdhAK+VJ+bDvbUvNd+KTLlA3bnDeYZaBsGH9LUhJ1M1yXfp9sEyBLMx6eA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -11812,6 +11833,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
+        "openai": "^5.10.1",
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -67,6 +67,19 @@ describe('validateAuthMethod', () => {
     });
   });
 
+  describe('USE_DEEPSEEK', () => {
+    it('should return null if DEEPSEEK_API_KEY is set', () => {
+      process.env.DEEPSEEK_API_KEY = 'key';
+      expect(validateAuthMethod(AuthType.USE_DEEPSEEK)).toBeNull();
+    });
+
+    it('should return an error message if DEEPSEEK_API_KEY is not set', () => {
+      expect(validateAuthMethod(AuthType.USE_DEEPSEEK)).toBe(
+        'DEEPSEEK_API_KEY environment variable not found. Add that to your environment and try again (no reload needed if using .env)!',
+      );
+    });
+  });
+
   it('should return an error message for an invalid auth method', () => {
     expect(validateAuthMethod('invalid-method')).toBe(
       'Invalid auth method selected.',

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -23,6 +23,13 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
+  if (authMethod === AuthType.USE_DEEPSEEK) {
+    if (!process.env.DEEPSEEK_API_KEY) {
+      return 'DEEPSEEK_API_KEY environment variable not found. Add that to your environment and try again (no reload needed if using .env)!';
+    }
+    return null;
+  }
+
   if (authMethod === AuthType.USE_VERTEX_AI) {
     const hasVertexProjectLocationConfig =
       !!process.env.GOOGLE_CLOUD_PROJECT && !!process.env.GOOGLE_CLOUD_LOCATION;

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -77,6 +77,7 @@ export function AuthDialog({
       value: AuthType.USE_GEMINI,
     },
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
+    { label: 'DeepSeek API Key', value: AuthType.USE_DEEPSEEK },
   ];
 
   const initialAuthIndex = items.findIndex((item) => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -513,6 +513,12 @@ export async function start_sandbox(
   if (process.env.GEMINI_API_KEY) {
     args.push('--env', `GEMINI_API_KEY=${process.env.GEMINI_API_KEY}`);
   }
+  if (process.env.DEEPSEEK_API_KEY) {
+    args.push('--env', `DEEPSEEK_API_KEY=${process.env.DEEPSEEK_API_KEY}`);
+  }
+  if (process.env.DEEPSEEK_BASE_URL) {
+    args.push('--env', `DEEPSEEK_BASE_URL=${process.env.DEEPSEEK_BASE_URL}`);
+  }
   if (process.env.GOOGLE_API_KEY) {
     args.push('--env', `GOOGLE_API_KEY=${process.env.GOOGLE_API_KEY}`);
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "ignore": "^7.0.0",
     "micromatch": "^4.0.8",
     "open": "^10.1.2",
+    "openai": "^5.10.1",
     "shell-quote": "^1.8.3",
     "simple-git": "^3.28.0",
     "strip-ansi": "^7.1.0",

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -9,13 +9,16 @@ import {
   createContentGenerator,
   AuthType,
   createContentGeneratorConfig,
+  ContentGenerator,
 } from './contentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { GoogleGenAI } from '@google/genai';
+import { createDeepseekGenerator } from './deepseekGenerator.js';
 import { Config } from '../config/config.js';
 
 vi.mock('../code_assist/codeAssist.js');
 vi.mock('@google/genai');
+vi.mock('./deepseekGenerator.js');
 
 const mockConfig = {} as unknown as Config;
 
@@ -59,6 +62,26 @@ describe('createContentGenerator', () => {
       },
     });
     expect(generator).toBe((mockGenerator as GoogleGenAI).models);
+  });
+
+  it('should create a DeepSeek content generator', async () => {
+    const mockGenerator = {} as unknown as ContentGenerator;
+    vi.mocked(createDeepseekGenerator).mockReturnValue(mockGenerator);
+    const generator = await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'deepseek-key',
+        authType: AuthType.USE_DEEPSEEK,
+        baseUrl: 'https://api.deepseek.com/v1',
+      },
+      mockConfig,
+    );
+    expect(createDeepseekGenerator).toHaveBeenCalledWith(
+      'deepseek-key',
+      'test-model',
+      'https://api.deepseek.com/v1',
+    );
+    expect(generator).toBe(mockGenerator);
   });
 });
 
@@ -135,5 +158,25 @@ describe('createContentGeneratorConfig', () => {
     );
     expect(config.apiKey).toBeUndefined();
     expect(config.vertexai).toBeUndefined();
+  });
+
+  it('should configure for DeepSeek when DEEPSEEK_API_KEY is set', async () => {
+    process.env.DEEPSEEK_API_KEY = 'ds-key';
+    process.env.DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
+    const config = await createContentGeneratorConfig(
+      mockConfig,
+      AuthType.USE_DEEPSEEK,
+    );
+    expect(config.apiKey).toBe('ds-key');
+    expect(config.baseUrl).toBe('https://api.deepseek.com/v1');
+  });
+
+  it('should not configure for DeepSeek if DEEPSEEK_API_KEY is empty', async () => {
+    process.env.DEEPSEEK_API_KEY = '';
+    const config = await createContentGeneratorConfig(
+      mockConfig,
+      AuthType.USE_DEEPSEEK,
+    );
+    expect(config.apiKey).toBeUndefined();
   });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -43,12 +43,14 @@ export enum AuthType {
   USE_GEMINI = 'gemini-api-key',
   USE_VERTEX_AI = 'vertex-ai',
   CLOUD_SHELL = 'cloud-shell',
+  USE_DEEPSEEK = 'deepseek-api-key',
 }
 
 export type ContentGeneratorConfig = {
   model: string;
   apiKey?: string;
   vertexai?: boolean;
+  baseUrl?: string;
   authType?: AuthType | undefined;
   proxy?: string | undefined;
 };
@@ -58,6 +60,8 @@ export function createContentGeneratorConfig(
   authType: AuthType | undefined,
 ): ContentGeneratorConfig {
   const geminiApiKey = process.env.GEMINI_API_KEY || undefined;
+  const deepseekApiKey = process.env.DEEPSEEK_API_KEY || undefined;
+  const deepseekBaseUrl = process.env.DEEPSEEK_BASE_URL || undefined;
   const googleApiKey = process.env.GOOGLE_API_KEY || undefined;
   const googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT || undefined;
   const googleCloudLocation = process.env.GOOGLE_CLOUD_LOCATION || undefined;
@@ -88,6 +92,12 @@ export function createContentGeneratorConfig(
       contentGeneratorConfig.proxy,
     );
 
+    return contentGeneratorConfig;
+  }
+
+  if (authType === AuthType.USE_DEEPSEEK && deepseekApiKey) {
+    contentGeneratorConfig.apiKey = deepseekApiKey;
+    contentGeneratorConfig.baseUrl = deepseekBaseUrl;
     return contentGeneratorConfig;
   }
 
@@ -138,6 +148,15 @@ export async function createContentGenerator(
     });
 
     return googleGenAI.models;
+  }
+
+  if (config.authType === AuthType.USE_DEEPSEEK) {
+    const { createDeepseekGenerator } = await import('./deepseekGenerator.js');
+    return createDeepseekGenerator(
+      config.apiKey ?? '',
+      config.model,
+      config.baseUrl,
+    );
   }
 
   throw new Error(

--- a/packages/core/src/core/deepseekGenerator.ts
+++ b/packages/core/src/core/deepseekGenerator.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenAI from 'openai';
+import { ContentGenerator } from './contentGenerator.js';
+import {
+  GenerateContentParameters,
+  GenerateContentResponse,
+  CountTokensParameters,
+  CountTokensResponse,
+  EmbedContentParameters,
+  EmbedContentResponse,
+  Part,
+  PartUnion,
+  Content,
+} from '@google/genai';
+
+const DEFAULT_BASE_URL = 'https://api.deepseek.com/v1';
+
+type ChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+function normalizeContent(
+  value: Content | PartUnion | string | Array<PartUnion | string>,
+): Content {
+  if (Array.isArray(value)) {
+    return {
+      role: 'user',
+      parts: value.map((v) => (typeof v === 'string' ? { text: v } : v)),
+    };
+  }
+  if (typeof value === 'string') {
+    return { role: 'user', parts: [{ text: value }] };
+  }
+  if ('parts' in (value as Content)) {
+    return value as Content;
+  }
+  return { role: 'user', parts: [value as Part] };
+}
+
+function toOpenAIMessages(
+  contents: Array<Content | PartUnion | string | Array<PartUnion | string>>,
+): ChatMessage[] {
+  return contents.map((c) => {
+    const normalized = normalizeContent(c);
+    const text = (normalized.parts ?? [])
+      .map((p: Part | string) => {
+        if (typeof p === 'string') return p;
+        return 'text' in p && (p as Part).text
+          ? ((p as Part).text as string)
+          : '';
+      })
+      .join('');
+    const role =
+      normalized.role === 'model' ? 'assistant' : (normalized.role ?? 'user');
+    return { role: role as ChatMessage['role'], content: text };
+  });
+}
+
+function fromOpenAI(content: string): GenerateContentResponse {
+  const response = new GenerateContentResponse();
+  response.candidates = [
+    {
+      content: { role: 'model', parts: [{ text: content }] },
+    },
+  ];
+  return response;
+}
+
+export function createDeepseekGenerator(
+  apiKey: string,
+  model: string,
+  baseUrl?: string,
+): ContentGenerator {
+  const client = new OpenAI({ apiKey, baseURL: baseUrl || DEFAULT_BASE_URL });
+
+  return {
+    async generateContent(params: GenerateContentParameters) {
+      const messages = toOpenAIMessages(
+        Array.isArray(params.contents) ? params.contents : [params.contents],
+      );
+      const resp = await client.chat.completions.create({
+        model: params.model ?? model,
+        messages,
+      });
+      const text = resp.choices[0]?.message?.content ?? '';
+      return fromOpenAI(text);
+    },
+
+    async generateContentStream(params: GenerateContentParameters) {
+      const result = await this.generateContent(params);
+      async function* gen() {
+        yield result;
+      }
+      return gen();
+    },
+
+    async countTokens(params: CountTokensParameters) {
+      const messages = toOpenAIMessages(
+        Array.isArray(params.contents) ? params.contents : [params.contents],
+      );
+      const resp = await client.chat.completions.create({
+        model: params.model ?? model,
+        messages,
+        max_tokens: 0,
+      });
+      return {
+        totalTokens: resp.usage?.prompt_tokens ?? 0,
+      } as CountTokensResponse;
+    },
+
+    async embedContent(params: EmbedContentParameters) {
+      const text = (
+        Array.isArray(params.contents) ? params.contents : [params.contents]
+      ).map((c: Content | PartUnion | string) => {
+        const normalized = normalizeContent(c);
+        return (normalized.parts ?? [])
+          .map((p: Part | string) =>
+            typeof p === 'string' ? p : ((p as Part).text ?? ''),
+          )
+          .join('');
+      });
+      const resp = await client.embeddings.create({
+        model: params.model ?? 'deepseek-embedding',
+        input: text,
+      });
+      return {
+        embeddings: resp.data.map((d) => ({ values: d.embedding })),
+      } as EmbedContentResponse;
+    },
+  } as ContentGenerator;
+}


### PR DESCRIPTION
## Summary
- add new `USE_DEEPSEEK` auth type
- validate DeepSeek auth in CLI and expose it in auth dialog
- propagate DEEPSEEK env vars to sandbox
- implement DeepSeek content generator using OpenAI SDK
- document DeepSeek env vars
- update tests for new auth method

## Testing
- `HTTP_PROXY= HTTPS_PROXY= http_proxy= https_proxy= npm run preflight`

------
https://chatgpt.com/codex/tasks/task_e_687ac0a1beb4832fba871777eb704677