### PR TITLE
Add provider switch command

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -44,8 +44,14 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
 - Obtain your API key from DeepSeek.
 - Set the `DEEPSEEK_API_KEY` environment variable. Optionally set `DEEPSEEK_BASE_URL` (defaults to `https://api.deepseek.com/v1`).
   ```bash
-  export DEEPSEEK_API_KEY="YOUR_DEEPSEEK_API_KEY"
+ export DEEPSEEK_API_KEY="YOUR_DEEPSEEK_API_KEY"
   ```
+
+Once your API keys are configured, you can switch between providers at any time using `/provider <provider> [model]`. For example:
+
+```bash
+/provider deepseek deepseek-reasoner
+```
 
 4.  **Vertex AI:**
     - Obtain your Google Cloud API key: [Get an API Key](https://cloud.google.com/vertex-ai/generative-ai/docs/start/api-keys?usertype=newuser)

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -73,6 +73,10 @@ Slash commands provide meta-level control over the CLI itself.
 - **`/auth`**
   - **Description:** Open a dialog that lets you change the authentication method.
 
+- **`/provider`**
+  - **Description:** Switch the authentication provider and model.
+  - **Usage:** `/provider <google|gemini|vertex|deepseek> [model]`
+
 - **`/about`**
   - **Description:** Show version info. Please share this information when filing issues.
 

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -26,6 +26,7 @@ import { ideCommand } from '../ui/commands/ideCommand.js';
 import { bugCommand } from '../ui/commands/bugCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
+import { providerCommand } from '../ui/commands/providerCommand.js';
 
 const loadBuiltInCommands = async (
   config: Config | null,
@@ -42,6 +43,7 @@ const loadBuiltInCommands = async (
     editorCommand,
     extensionsCommand,
     helpCommand,
+    providerCommand,
     ideCommand(config),
     mcpCommand,
     memoryCommand,

--- a/packages/cli/src/ui/commands/providerCommand.test.ts
+++ b/packages/cli/src/ui/commands/providerCommand.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { providerCommand } from './providerCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+import { AuthType } from '@google/gemini-cli-core';
+import { SettingScope } from '../../config/settings.js';
+
+describe('providerCommand', () => {
+  let mockContext: CommandContext;
+  const refreshAuth = vi.fn();
+  const setModel = vi.fn();
+  const getModel = vi.fn(() => 'deepseek-reasoner');
+  const setValue = vi.fn();
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          refreshAuth,
+          setModel,
+          getModel,
+        },
+        settings: { setValue, merged: {} },
+      },
+    });
+    refreshAuth.mockClear();
+    setModel.mockClear();
+    setValue.mockClear();
+  });
+
+  it('should return usage message when no args are provided', async () => {
+    if (!providerCommand.action) throw new Error('no action');
+    const result = await providerCommand.action(mockContext, '');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Usage: /provider <google|gemini|vertex|deepseek> [model]',
+    });
+  });
+
+  it('should refresh auth and set model', async () => {
+    if (!providerCommand.action) throw new Error('no action');
+    await providerCommand.action(mockContext, 'deepseek deepseek-reasoner');
+    expect(refreshAuth).toHaveBeenCalledWith(AuthType.USE_DEEPSEEK);
+    expect(setModel).toHaveBeenCalledWith('deepseek-reasoner');
+    expect(setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'selectedAuthType',
+      AuthType.USE_DEEPSEEK,
+    );
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.INFO,
+        text: expect.stringContaining('deepseek'),
+      },
+      expect.any(Number),
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/providerCommand.ts
+++ b/packages/cli/src/ui/commands/providerCommand.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthType } from '@google/gemini-cli-core';
+import {
+  type CommandContext,
+  type SlashCommand,
+  type SlashCommandActionReturn,
+} from './types.js';
+import { MessageType } from '../types.js';
+import { SettingScope } from '../../config/settings.js';
+
+const PROVIDER_MAP: Record<string, AuthType> = {
+  google: AuthType.LOGIN_WITH_GOOGLE,
+  gemini: AuthType.USE_GEMINI,
+  vertex: AuthType.USE_VERTEX_AI,
+  deepseek: AuthType.USE_DEEPSEEK,
+  cloudshell: AuthType.CLOUD_SHELL,
+};
+
+export const providerCommand: SlashCommand = {
+  name: 'provider',
+  description: 'switch provider and model. Usage: /provider <provider> [model]',
+  async action(context: CommandContext, args: string): Promise<void | SlashCommandActionReturn> {
+    const parts = args.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Usage: /provider <google|gemini|vertex|deepseek> [model]',
+      };
+    }
+    const providerArg = parts[0].toLowerCase();
+    const modelArg = parts[1];
+    const authType = PROVIDER_MAP[providerArg];
+    if (!authType) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Unknown provider: ${providerArg}`,
+      };
+    }
+    const config = context.services.config;
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Configuration unavailable.',
+      };
+    }
+
+    await config.refreshAuth(authType);
+    if (modelArg) {
+      config.setModel(modelArg);
+    }
+    context.services.settings.setValue(SettingScope.User, 'selectedAuthType', authType);
+
+    context.ui.addItem(
+      {
+        type: MessageType.INFO,
+        text: `Switched provider to ${providerArg} using model ${config.getModel()}.`,
+      },
+      Date.now(),
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- add a `/provider` command for switching providers and models
- document the new command and provider switching in docs
- include a unit test for the command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ad1c67c38832f86adc126fc14d1b0