### PR TITLE
Refactor for vendor‑neutral API key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,32 +43,23 @@ With the Gemini CLI you can:
 
 You are now ready to use the Gemini CLI!
 
-### Use a Gemini API key:
+### Use an API key
 
-The Gemini API provides a free tier with [100 requests per day](https://ai.google.dev/gemini-api/docs/rate-limits#free-tier) using Gemini 2.5 Pro, control over which model you use, and access to higher rate limits (with a paid plan):
+Configure the CLI by providing a base URL for your model server and an API key:
 
-1. Generate a key from [Google AI Studio](https://aistudio.google.com/apikey).
-2. Set it as an environment variable in your terminal. Replace `YOUR_API_KEY` with your generated key.
-
-   ```bash
-   export GEMINI_API_KEY="YOUR_API_KEY"
-   ```
-
-3. (Optionally) Upgrade your Gemini API project to a paid plan on the API key page (will automatically unlock [Tier 1 rate limits](https://ai.google.dev/gemini-api/docs/rate-limits#tier-1))
-
-### Use a Vertex AI API key:
-
-The Vertex AI API provides a [free tier](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview) using express mode for Gemini 2.5 Pro, control over which model you use, and access to higher rate limits with a billing account:
-
-1. Generate a key from [Google Cloud](https://cloud.google.com/vertex-ai/generative-ai/docs/start/api-keys).
-2. Set it as an environment variable in your terminal. Replace `YOUR_API_KEY` with your generated key and set GOOGLE_GENAI_USE_VERTEXAI to true
+1. Set the base URL for your model endpoint.
 
    ```bash
-   export GOOGLE_API_KEY="YOUR_API_KEY"
-   export GOOGLE_GENAI_USE_VERTEXAI=true
+   export API_BASE_URL="https://model.example.com"
    ```
 
-3. (Optionally) Add a billing account on your project to get access to [higher usage limits](https://cloud.google.com/vertex-ai/generative-ai/docs/quotas)
+2. Set your API key.
+
+   ```bash
+   export API_KEY="YOUR_API_KEY"
+   ```
+
+After these variables are set the CLI will connect to the configured endpoint using the API key for authentication.
 
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -4,42 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import updateNotifier from 'update-notifier';
-import semver from 'semver';
-import { getPackageJson } from '../../utils/package.js';
+// Update checking disabled in vendor neutral build
+// import updateNotifier from 'update-notifier';
+// import semver from 'semver';
+// import { getPackageJson } from '../../utils/package.js';
 
 export async function checkForUpdates(): Promise<string | null> {
-  try {
-    // Skip update check when running from source (development mode)
-    if (process.env.DEV === 'true') {
-      return null;
-    }
-
-    const packageJson = await getPackageJson();
-    if (!packageJson || !packageJson.name || !packageJson.version) {
-      return null;
-    }
-    const notifier = updateNotifier({
-      pkg: {
-        name: packageJson.name,
-        version: packageJson.version,
-      },
-      // check every time
-      updateCheckInterval: 0,
-      // allow notifier to run in scripts
-      shouldNotifyInNpmScript: true,
-    });
-
-    if (
-      notifier.update &&
-      semver.gt(notifier.update.latest, notifier.update.current)
-    ) {
-      return `Gemini CLI update available! ${notifier.update.current} → ${notifier.update.latest}\nRun npm install -g ${packageJson.name} to update`;
-    }
-
-    return null;
-  } catch (e) {
-    console.warn('Failed to check for updates: ' + e);
-    return null;
-  }
+  // Update checks disabled
+  return null;
 }

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -14,6 +14,7 @@ import {
   GoogleGenAI,
 } from '@google/genai';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
+import { HttpModelClient } from './httpModelClient.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import { Config } from '../config/config.js';
 import { getEffectiveModel } from './modelCheck.js';
@@ -115,6 +116,11 @@ export async function createContentGenerator(
       'User-Agent': `GeminiCLI/${version} (${process.platform}; ${process.arch})`,
     },
   };
+  const baseUrl = process.env.API_BASE_URL;
+  const apiKey = process.env.API_KEY;
+  if (baseUrl && apiKey) {
+    return new HttpModelClient({ baseUrl, apiKey, model: config.model });
+  }
   if (
     config.authType === AuthType.LOGIN_WITH_GOOGLE ||
     config.authType === AuthType.CLOUD_SHELL

--- a/packages/core/src/core/httpModelClient.ts
+++ b/packages/core/src/core/httpModelClient.ts
@@ -1,0 +1,71 @@
+/**
+ * Vendor-neutral HTTP client that communicates with a model server using
+ * a base URL and API key authentication.
+ */
+import type {
+  CountTokensParameters,
+  CountTokensResponse,
+  EmbedContentParameters,
+  EmbedContentResponse,
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from '@google/genai';
+
+export interface HttpModelClientConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export class HttpModelClient {
+  constructor(private readonly config: HttpModelClientConfig) {}
+
+  private async request<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(`${this.config.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  async generateContent(
+    req: GenerateContentParameters,
+  ): Promise<GenerateContentResponse> {
+    return this.request<GenerateContentResponse>('/generate', {
+      model: this.config.model,
+      ...req,
+    });
+  }
+
+  async generateContentStream(
+    req: GenerateContentParameters,
+  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    const resp = await this.request<GenerateContentResponse>('/generate', {
+      model: this.config.model,
+      ...req,
+    });
+    async function* gen() {
+      yield resp;
+    }
+    return gen();
+  }
+
+  async countTokens(
+    req: CountTokensParameters,
+  ): Promise<CountTokensResponse> {
+    return this.request<CountTokensResponse>('/countTokens', req);
+  }
+
+  async embedContent(
+    req: EmbedContentParameters,
+  ): Promise<EmbedContentResponse> {
+    return this.request<EmbedContentResponse>('/embed', req);
+  }
+}

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -35,7 +35,8 @@ import {
 } from './metrics.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
 import { uiTelemetryService, UiEvent } from './uiTelemetry.js';
-import { ClearcutLogger } from './clearcut-logger/clearcut-logger.js';
+// Clearcut telemetry disabled
+// import { ClearcutLogger } from './clearcut-logger/clearcut-logger.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 
 const shouldLogUserPrompts = (config: Config): boolean =>
@@ -51,7 +52,7 @@ export function logCliConfiguration(
   config: Config,
   event: StartSessionEvent,
 ): void {
-  ClearcutLogger.getInstance(config)?.logStartSessionEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
@@ -80,7 +81,7 @@ export function logCliConfiguration(
 }
 
 export function logUserPrompt(config: Config, event: UserPromptEvent): void {
-  ClearcutLogger.getInstance(config)?.logNewPromptEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
@@ -109,7 +110,7 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent);
-  ClearcutLogger.getInstance(config)?.logToolCallEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
@@ -142,7 +143,7 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
 }
 
 export function logApiRequest(config: Config, event: ApiRequestEvent): void {
-  ClearcutLogger.getInstance(config)?.logApiRequestEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
@@ -164,7 +165,7 @@ export function logFlashFallback(
   config: Config,
   event: FlashFallbackEvent,
 ): void {
-  ClearcutLogger.getInstance(config)?.logFlashFallbackEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
@@ -189,7 +190,7 @@ export function logApiError(config: Config, event: ApiErrorEvent): void {
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent);
-  ClearcutLogger.getInstance(config)?.logApiErrorEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
@@ -231,7 +232,7 @@ export function logApiResponse(config: Config, event: ApiResponseEvent): void {
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent);
-  ClearcutLogger.getInstance(config)?.logApiResponseEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
   const attributes: LogAttributes = {
     ...getCommonAttributes(config),
@@ -294,7 +295,7 @@ export function logLoopDetected(
   config: Config,
   event: LoopDetectedEvent,
 ): void {
-  ClearcutLogger.getInstance(config)?.logLoopDetectedEvent(event);
+  // ClearcutLogger disabled
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {


### PR DESCRIPTION
## Summary
- disable update checks
- disable Clearcut telemetry
- add a generic `HttpModelClient` that talks to an API base URL using an API key
- allow `createContentGenerator` to use the vendor-neutral model client when `API_BASE_URL` and `API_KEY` are set
- document new environment variables in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bb0d0dbd0832f9f952a5da317f039