### PR TITLE
Introduce vendor-neutral HTTP model client

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ The Vertex AI API provides a [free tier](https://cloud.google.com/vertex-ai/gene
 
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 
+### Use a generic API endpoint:
+
+If you have a model server that exposes Gemini compatible APIs, you can direct the CLI to use it by setting an API base URL and key:
+
+1. Set `API_BASE_URL` to the base URL of your server.
+2. Set `GEMINI_API_KEY` with your API key.
+
+```bash
+export API_BASE_URL="https://example.com/api"
+export GEMINI_API_KEY="YOUR_API_KEY"
+```
+
 ## Examples
 
 Once the CLI is running, you can start interacting with Gemini from your shell.

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -13,6 +13,7 @@ import {
   EmbedContentParameters,
   GoogleGenAI,
 } from '@google/genai';
+import { HttpModelClient } from './httpModelClient.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import { Config } from '../config/config.js';
@@ -125,6 +126,10 @@ export async function createContentGenerator(
       gcConfig,
       sessionId,
     );
+  }
+
+  if (process.env.API_BASE_URL && config.apiKey) {
+    return new HttpModelClient(process.env.API_BASE_URL, config.apiKey);
   }
 
   if (

--- a/packages/core/src/core/httpModelClient.ts
+++ b/packages/core/src/core/httpModelClient.ts
@@ -1,0 +1,75 @@
+import {
+  CountTokensParameters,
+  CountTokensResponse,
+  GenerateContentParameters,
+  GenerateContentResponse,
+  EmbedContentParameters,
+  EmbedContentResponse,
+} from '@google/genai';
+import { ContentGenerator } from './contentGenerator.js';
+
+export class HttpModelClient implements ContentGenerator {
+  constructor(private baseUrl: string, private apiKey: string) {}
+
+  private async request<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(`${this.baseUrl}/${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  async generateContent(request: GenerateContentParameters): Promise<GenerateContentResponse> {
+    return this.request<GenerateContentResponse>('generate', request);
+  }
+
+  async generateContentStream(
+    request: GenerateContentParameters,
+  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    const res = await fetch(`${this.baseUrl}/stream`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!res.ok || !res.body) {
+      throw new Error(`Stream request failed with status ${res.status}`);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    async function* streamGenerator(): AsyncGenerator<GenerateContentResponse> {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value);
+        try {
+          yield JSON.parse(chunk) as GenerateContentResponse;
+        } catch {
+          // Ignore parse errors for partial chunks
+        }
+      }
+    }
+
+    return streamGenerator();
+  }
+
+  async countTokens(request: CountTokensParameters): Promise<CountTokensResponse> {
+    return this.request<CountTokensResponse>('countTokens', request);
+  }
+
+  async embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse> {
+    return this.request<EmbedContentResponse>('embed', request);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './core/turn.js';
 export * from './core/geminiRequest.js';
 export * from './core/coreToolScheduler.js';
 export * from './core/nonInteractiveToolExecutor.js';
+export * from './core/httpModelClient.js';
 
 export * from './code_assist/codeAssist.js';
 export * from './code_assist/oauth2.js';


### PR DESCRIPTION
## Summary
- add `HttpModelClient` implementing basic fetch-based calls
- integrate new client when `API_BASE_URL` is set
- document generic API usage in README

## Testing
- `npm test` *(fails: Failed to resolve entry for package `@google/gemini-cli-core`)*

------
https://chatgpt.com/codex/tasks/task_e_687bb0d0dbd0832f9f952a5da317f039